### PR TITLE
Fix app scafolding for vue vite

### DIFF
--- a/src/app/stack/vue/vite.ts
+++ b/src/app/stack/vue/vite.ts
@@ -18,7 +18,6 @@ export class VueViteBuilder implements AppBuilder {
     await execa('npm', ['create', `vue@${version}`, name, '--', '--ts'], { stdio: 'inherit' })
     await execa('npm', ['i'], { stdio: 'inherit', cwd: name })
 
-    const configName = version === 3 ? 'tsconfig.app.json' : 'tsconfig.json'
     const tsConfig = await getTSConfig(name, configName)
 
     tsConfig.compilerOptions.allowJs = true

--- a/src/app/stack/vue/vite.ts
+++ b/src/app/stack/vue/vite.ts
@@ -18,6 +18,7 @@ export class VueViteBuilder implements AppBuilder {
     await execa('npm', ['create', `vue@${version}`, name, '--', '--ts'], { stdio: 'inherit' })
     await execa('npm', ['i'], { stdio: 'inherit', cwd: name })
 
+    const configName = 'tsconfig.json'
     const tsConfig = await getTSConfig(name, configName)
 
     tsConfig.compilerOptions.allowJs = true


### PR DESCRIPTION
`npm create vue@2 -- --ts`  and `npm create vue@3 -- --ts`  both create same ts config file namely `tsconfig.json`

By removing the offending line, vue vite can be scaffold  