### PR TITLE
fix(build): throw error if any command is rejected

### DIFF
--- a/src/build/exec.ts
+++ b/src/build/exec.ts
@@ -4,7 +4,7 @@ import execa from 'execa'
 export async function awaitedExec(command: string, args: string[], options: { cwd?: string }, log: (line: string) => void, resolveOn: (line: string) => boolean) {
   const execaInstance = execa(command, args, { env: { FORCE_COLOR: 'true' }, ...options })
 
-  await new Promise<void>((resolve) => {
+  await new Promise<void>((resolve, reject) => {
     execaInstance.stdout?.addListener('data', (chunk: Buffer) => {
       const str = chunk.toString()
 
@@ -14,6 +14,11 @@ export async function awaitedExec(command: string, args: string[], options: { cw
       lines.forEach(log)
 
       if (lines.some(resolveOn)) resolve()
+    })
+    execaInstance.stderr?.addListener('data', (chunk: Buffer) => {
+      const error = chunk.toString()
+
+      reject(new Error(error))
     })
   })
 }

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -50,13 +50,20 @@ export async function build(folders: string[]) {
   })
 
   for (const { config, command, args, cwd } of commands) {
-    await awaitedExec(
-      command,
-      args,
-      { cwd },
-      line => console.log(` [${config.name}] ${line}`),
-      line => /Build (\w+) completed/.test(line)
-    )
+    try {
+      await awaitedExec(
+        command,
+        args,
+        { cwd },
+        line => console.log(` [${config.name}] ${line}`),
+        line => /Build (\w+) completed/.test(line)
+      )
+    } catch (e) {
+      const commandString = `${command} ${args.join(' ')}`
+      const message = String((e as Error).message).trim()
+
+      throwError(`Failed to execute command: ${commandString}\n${message}`)
+    }
   }
   console.log(chalk.bgGreen(' READY '), chalk.green('Ready for development'))
   console.log(chalk.grey([


### PR DESCRIPTION
### Description

Fixes an issue with `rete-kit build` completing with exit code 0 and no errors if any command throws an error. For example, when `node_modules` are missing
![image](https://github.com/retejs/rete-kit/assets/8259641/22e93393-102d-4b10-82ec-29b1f0aac629)

Expected result
![image](https://github.com/retejs/rete-kit/assets/8259641/154eed79-f9cb-4bb4-813a-56fd4175772b)

### Checklist

<!-- Mark the items that apply to this pull request -->

- [x] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).
