### PR TITLE
Fix build exit code handling

### DIFF
--- a/src/build/exec.ts
+++ b/src/build/exec.ts
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import execa from 'execa'
 
-export async function awaitedExec(command: string, args: string[], options: { cwd?: string }, log: (line: string) => void, resolveOn: (line: string) => boolean) {
+type Events = {
+  log: (line: string) => void
+  error: (line: string) => void
+  resolveOn: (line: string) => boolean
+}
+
+export async function awaitedExec(command: string, args: string[], options: { cwd?: string }, events: Events) {
   const execaInstance = execa(command, args, { env: { FORCE_COLOR: 'true' }, ...options })
 
   await new Promise<void>((resolve, reject) => {
@@ -11,14 +17,24 @@ export async function awaitedExec(command: string, args: string[], options: { cw
       if (!str) return
       const lines = str.trim().split('\n')
 
-      lines.forEach(log)
+      lines.forEach(events.log)
 
-      if (lines.some(resolveOn)) resolve()
+      if (lines.some(events.resolveOn)) resolve()
     })
     execaInstance.stderr?.addListener('data', (chunk: Buffer) => {
-      const error = chunk.toString()
+      const str = chunk.toString()
 
-      reject(new Error(error))
+      if (!str) return
+      const lines = str.trim().split('\n')
+
+      lines.forEach(events.error)
+    })
+
+    // reject on exit code !== 0
+    execaInstance.on('exit', code => {
+      if (code !== 0) {
+        reject(new Error(`Command failed with exit code ${code}`))
+      }
     })
   })
 }

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -55,14 +55,17 @@ export async function build(folders: string[]) {
         command,
         args,
         { cwd },
-        line => console.log(` [${config.name}] ${line}`),
-        line => /Build (\w+) completed/.test(line)
+        {
+          log: line => console.log(` [${config.name}] ${line}`),
+          error: line => console.error(chalk.red(` [${config.name}] ${line}`)),
+          resolveOn: line => /Build (\w+) completed/.test(line)
+        }
       )
     } catch (e) {
       const commandString = `${command} ${args.join(' ')}`
       const message = String((e as Error).message).trim()
 
-      throwError(`Failed to execute command: ${commandString}\n${message}`)
+      throwError(`Failed to execute: ${commandString}. ${message}`)
     }
   }
   console.log(chalk.bgGreen(' READY '), chalk.green('Ready for development'))


### PR DESCRIPTION
### Description

Extends https://github.com/retejs/rete-kit/pull/37 by handling `exit` event instead of `stderr`

### Checklist

<!-- Mark the items that apply to this pull request -->

- x] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).

