### PR TITLE
fix(app): pin scaffold tools for regression build stability

### DIFF
--- a/src/app/stack/lit/vite.ts
+++ b/src/app/stack/lit/vite.ts
@@ -13,7 +13,7 @@ export class LitViteBuilder implements AppBuilder {
 
   public async create(name: string, version: number) {
     await execa('npm', [
-      'create', `vite@latest`, name, '--', '--template', 'vanilla-ts', '-y'
+      'create', 'vite@7', name, '--', '--template', 'vanilla-ts', '-y'
     ], { stdio: 'inherit' })
     await execa('npm', [
       'i',

--- a/src/app/stack/nuxt/index.ts
+++ b/src/app/stack/nuxt/index.ts
@@ -14,7 +14,7 @@ export class NuxtBuilder implements AppBuilder {
   public foundation = 'vue' as const
 
   public async create(name: string) {
-    await execa('npx', ['nuxi@3', 'init', name, '--packageManager', 'npm', '--gitInit'], { stdio: 'inherit' })
+    await execa('npx', ['nuxi@3', 'init', name, '--template', 'v3', '--packageManager', 'npm', '--gitInit'], { stdio: 'inherit' })
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/app/stack/vite/index.ts
+++ b/src/app/stack/vite/index.ts
@@ -14,7 +14,7 @@ export class ViteBuilder implements AppBuilder {
 
   public async create(name: string) {
     await execa('npm', [
-      'create', `vite@latest`, name, '--', '--template', 'vanilla-ts', '-y'
+      'create', 'vite@7', name, '--', '--template', 'vanilla-ts', '-y'
     ], { stdio: 'inherit' })
     await execa('npm', ['i'], { cwd: join(process.cwd(), name), stdio: 'inherit' })
 

--- a/src/app/stack/vue/legacy.ts
+++ b/src/app/stack/vue/legacy.ts
@@ -19,7 +19,12 @@ export class VueBuilder implements AppBuilder {
       ? 'vue2'
       : 'vue3')
 
-    await execa('npx', ['--package', `@vue/cli@`, 'vue', 'create', name, '--preset', presetFolder], { stdio: 'inherit' })
+    await execa('npx', [
+      '--package', `@vue/cli@`, 'vue', 'create', name,
+      '--preset', presetFolder,
+      '-m', 'npm',
+      '-r', 'https://registry.npmjs.org'
+    ], { stdio: 'inherit' })
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/app/template-builder.ts
+++ b/src/app/template-builder.ts
@@ -16,12 +16,16 @@ export type DefaultTemplateKey = 'zoom-at' | 'react-render' | `react${number}` |
   | 'context-menu' | 'import-area-extensions' | 'minimap' | 'reroute' | `stack-${string}`
 
 export class TemplateBuilder<Key extends string> {
-  blockCommentRegex = /\/\* \[(!?[\w-]+)\][\n ]+(.*?)?[\n ]?\[\/\1\] \*\//gs
+  blockCommentRegex = /\/\* \[(!?[\w-]+)\][\r\n ]+(.*?)?[\r\n ]?\[\/\1\] \*\//gs
 
   constructor(private keys: Key[]) { }
 
+  private normalizeLineEndings(code: string) {
+    return code.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+  }
+
   async load(name: string) {
-    return fs.promises.readFile(join(templatesPath, name), { encoding: 'utf-8' })
+    return this.normalizeLineEndings(await fs.promises.readFile(join(templatesPath, name), { encoding: 'utf-8' }))
   }
 
   async getTemplates() {
@@ -38,7 +42,7 @@ export class TemplateBuilder<Key extends string> {
 
   build(template: string, format = true) {
     const keep = (key: Key) => this.keys.includes(key)
-    const code = this.replace(template, keep)
+    const code = this.replace(this.normalizeLineEndings(template), keep)
 
     return format
       ? prettier.format(code, { singleQuote: true, parser: 'typescript' })

--- a/test/template.test.ts
+++ b/test/template.test.ts
@@ -24,4 +24,23 @@ import { A } from 'pkg';
 
 const b = new A();\n`)
   })
+
+  it('handles CRLF line endings with nested blocks', () => {
+    const builder = new TemplateBuilder(['selectable', 'reroute', 'dataflow'])
+    const code = builder.build(
+      '/* [selectable]\r\n'
+      + 'const selector = 1;\r\n'
+      + '/* [reroute]\r\n'
+      + 'const reroute = 1;\r\n'
+      + '[/reroute] */\r\n'
+      + '[/selectable] */\r\n'
+      + '/* [dataflow] const process = 1 [/dataflow] */',
+      false
+    )
+
+    expect(code).toContain('const selector = 1;')
+    expect(code).toContain('const reroute = 1;')
+    expect(code).toContain('const process = 1')
+    expect(code).not.toContain('[/selectable]')
+  })
 })


### PR DESCRIPTION
### Description

Pin create-vite to v7 for lit-vite and vite stacks, pass --template v3 to nuxi init, and force npm registry flags for vue-cli so CI scaffolds stay non-interactive.

### Related Issues

<!-- If your pull request is related to any GitHub issue(s), mention them here. -->

### Checklist

<!-- Mark the items that apply to this pull request -->

- [ ] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [ ] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).

### Additional Notes

<!-- Any additional information or notes for the reviewers. -->
