### PR TITLE
Feature/stack major upgrades

### DIFF
--- a/.github/workflows/regression-build.yml
+++ b/.github/workflows/regression-build.yml
@@ -12,6 +12,17 @@ on:
       mac:
         description: MacOS runner ('-' to skip)
         default: macos-latest
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: choice
+        options:
+        - npm
+        - github
+        default: npm
+      kit-version:
+        description: 'Rete Kit version/reference'
+        default: latest
+        type: string
 
 
   schedule:
@@ -25,6 +36,8 @@ jobs:
     uses: ./.github/workflows/test-build-angular.yml
     with:
       os: ${{ inputs.linux }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   win-angular:
     name: "Windows: Angular"
@@ -33,6 +46,8 @@ jobs:
     uses: ./.github/workflows/test-build-angular.yml
     with:
       os: ${{ inputs.win }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   mac-angular:
     name: "MacOS: Angular"
@@ -41,6 +56,8 @@ jobs:
     uses: ./.github/workflows/test-build-angular.yml
     with:
       os: ${{ inputs.mac }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
 # React
   linux-react:
@@ -49,6 +66,8 @@ jobs:
     uses: ./.github/workflows/test-build-react.yml
     with:
       os: ${{ inputs.linux }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   win-react:
     name: "Windows: React"
@@ -57,6 +76,8 @@ jobs:
     uses: ./.github/workflows/test-build-react.yml
     with:
       os: ${{ inputs.win }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   mac-react:
     name: "MacOS: React"
@@ -65,6 +86,8 @@ jobs:
     uses: ./.github/workflows/test-build-react.yml
     with:
       os: ${{ inputs.mac }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
 # Vue
   linux-vue:
@@ -73,6 +96,8 @@ jobs:
     uses: ./.github/workflows/test-build-vue.yml
     with:
       os: ${{ inputs.linux }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   win-vue:
     name: "Windows: Vue"
@@ -81,6 +106,8 @@ jobs:
     uses: ./.github/workflows/test-build-vue.yml
     with:
       os: ${{ inputs.win }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   mac-vue:
     name: "MacOS: Vue"
@@ -89,6 +116,8 @@ jobs:
     uses: ./.github/workflows/test-build-vue.yml
     with:
       os: ${{ inputs.mac }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
 # Svelte
 
@@ -98,6 +127,8 @@ jobs:
     uses: ./.github/workflows/test-build-svelte.yml
     with:
       os: ${{ inputs.linux }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   win-svelte:
     name: "Windows: Svelte"
@@ -106,6 +137,8 @@ jobs:
     uses: ./.github/workflows/test-build-svelte.yml
     with:
       os: ${{ inputs.win }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   mac-svelte:
     name: "MacOS: Svelte"
@@ -114,6 +147,8 @@ jobs:
     uses: ./.github/workflows/test-build-svelte.yml
     with:
       os: ${{ inputs.mac }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
 # Vite
   linux-vite:
@@ -122,6 +157,8 @@ jobs:
     uses: ./.github/workflows/test-build-vite.yml
     with:
       os: ${{ inputs.linux }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   win-vite:
     name: "Windows: Vite"
@@ -130,6 +167,8 @@ jobs:
     uses: ./.github/workflows/test-build-vite.yml
     with:
       os: ${{ inputs.win }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   mac-vite:
     name: "MacOS: Vite"
@@ -138,6 +177,8 @@ jobs:
     uses: ./.github/workflows/test-build-vite.yml
     with:
       os: ${{ inputs.mac }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
 # React Vite
   linux-react-vite:
@@ -146,6 +187,8 @@ jobs:
     uses: ./.github/workflows/test-build-react-vite.yml
     with:
       os: ${{ inputs.linux }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   win-react-vite:
     name: "Windows: React Vite"
@@ -154,6 +197,8 @@ jobs:
     uses: ./.github/workflows/test-build-react-vite.yml
     with:
       os: ${{ inputs.win }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   mac-react-vite:
     name: "MacOS: React Vite"
@@ -162,6 +207,8 @@ jobs:
     uses: ./.github/workflows/test-build-react-vite.yml
     with:
       os: ${{ inputs.mac }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
 # Vue Vite
   linux-vue-vite:
@@ -170,6 +217,8 @@ jobs:
     uses: ./.github/workflows/test-build-vue-vite.yml
     with:
       os: ${{ inputs.linux }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   win-vue-vite:
     name: "Windows: Vue Vite"
@@ -178,6 +227,8 @@ jobs:
     uses: ./.github/workflows/test-build-vue-vite.yml
     with:
       os: ${{ inputs.win }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   mac-vue-vite:
     name: "MacOS: Vue Vite"
@@ -186,6 +237,8 @@ jobs:
     uses: ./.github/workflows/test-build-vue-vite.yml
     with:
       os: ${{ inputs.mac }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
 # Next
   linux-next:
@@ -194,6 +247,8 @@ jobs:
     uses: ./.github/workflows/test-build-next.yml
     with:
       os: ${{ inputs.linux }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   win-next:
     name: "Windows: Next"
@@ -202,6 +257,8 @@ jobs:
     uses: ./.github/workflows/test-build-next.yml
     with:
       os: ${{ inputs.win }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   mac-next:
     name: "MacOS: Next"
@@ -210,6 +267,8 @@ jobs:
     uses: ./.github/workflows/test-build-next.yml
     with:
       os: ${{ inputs.mac }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
 # Nuxt
   linux-nuxt:
@@ -218,6 +277,8 @@ jobs:
     uses: ./.github/workflows/test-build-nuxt.yml
     with:
       os: ${{ inputs.linux }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   win-nuxt:
     name: "Windows: Nuxt"
@@ -226,6 +287,8 @@ jobs:
     uses: ./.github/workflows/test-build-nuxt.yml
     with:
       os: ${{ inputs.win }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   mac-nuxt:
     name: "MacOS: Nuxt"
@@ -234,6 +297,8 @@ jobs:
     uses: ./.github/workflows/test-build-nuxt.yml
     with:
       os: ${{ inputs.mac }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
 # Lit
   linux-lit:
@@ -242,6 +307,8 @@ jobs:
     uses: ./.github/workflows/test-build-lit-vite.yml
     with:
       os: ${{ inputs.linux }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   win-lit:
     name: "Windows: Lit"
@@ -250,6 +317,8 @@ jobs:
     uses: ./.github/workflows/test-build-lit-vite.yml
     with:
       os: ${{ inputs.win }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}
 
   mac-lit:
     name: "MacOS: Lit"
@@ -258,3 +327,5 @@ jobs:
     uses: ./.github/workflows/test-build-lit-vite.yml
     with:
       os: ${{ inputs.mac }}
+      kit-source: ${{ inputs.kit-source || 'npm' }}
+      kit-version: ${{ inputs.kit-version || 'latest' }}

--- a/.github/workflows/regression-build.yml
+++ b/.github/workflows/regression-build.yml
@@ -34,6 +34,7 @@ jobs:
     name: "Ubuntu: Angular"
     if: ${{ always() && inputs.linux != '-' }}
     uses: ./.github/workflows/test-build-angular.yml
+    secrets: inherit
     with:
       os: ${{ inputs.linux }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -44,6 +45,7 @@ jobs:
     if: ${{ always() && inputs.win != '-' }}
     needs: linux-angular
     uses: ./.github/workflows/test-build-angular.yml
+    secrets: inherit
     with:
       os: ${{ inputs.win }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -54,6 +56,7 @@ jobs:
     if: ${{ always() && inputs.mac != '-' }}
     needs: win-angular
     uses: ./.github/workflows/test-build-angular.yml
+    secrets: inherit
     with:
       os: ${{ inputs.mac }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -64,6 +67,7 @@ jobs:
     name: "Ubuntu: React"
     if: ${{ always() && inputs.linux != '-' }}
     uses: ./.github/workflows/test-build-react.yml
+    secrets: inherit
     with:
       os: ${{ inputs.linux }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -74,6 +78,7 @@ jobs:
     if: ${{ always() && inputs.win != '-' }}
     needs: linux-react
     uses: ./.github/workflows/test-build-react.yml
+    secrets: inherit
     with:
       os: ${{ inputs.win }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -84,6 +89,7 @@ jobs:
     if: ${{ always() && inputs.mac != '-' }}
     needs: win-react
     uses: ./.github/workflows/test-build-react.yml
+    secrets: inherit
     with:
       os: ${{ inputs.mac }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -94,6 +100,7 @@ jobs:
     name: "Ubuntu: Vue"
     if: ${{ always() && inputs.linux != '-' }}
     uses: ./.github/workflows/test-build-vue.yml
+    secrets: inherit
     with:
       os: ${{ inputs.linux }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -104,6 +111,7 @@ jobs:
     if: ${{ always() && inputs.win != '-' }}
     needs: linux-vue
     uses: ./.github/workflows/test-build-vue.yml
+    secrets: inherit
     with:
       os: ${{ inputs.win }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -114,6 +122,7 @@ jobs:
     if: ${{ always() && inputs.mac != '-' }}
     needs: win-vue
     uses: ./.github/workflows/test-build-vue.yml
+    secrets: inherit
     with:
       os: ${{ inputs.mac }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -125,6 +134,7 @@ jobs:
     name: "Ubuntu: Svelte"
     if: ${{ always() && inputs.linux != '-' }}
     uses: ./.github/workflows/test-build-svelte.yml
+    secrets: inherit
     with:
       os: ${{ inputs.linux }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -135,6 +145,7 @@ jobs:
     if: ${{ always() && inputs.win != '-' }}
     needs: linux-svelte
     uses: ./.github/workflows/test-build-svelte.yml
+    secrets: inherit
     with:
       os: ${{ inputs.win }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -145,6 +156,7 @@ jobs:
     if: ${{ always() && inputs.mac != '-' }}
     needs: win-svelte
     uses: ./.github/workflows/test-build-svelte.yml
+    secrets: inherit
     with:
       os: ${{ inputs.mac }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -155,6 +167,7 @@ jobs:
     name: "Ubuntu: Vite"
     if: ${{ always() && inputs.linux != '-' }}
     uses: ./.github/workflows/test-build-vite.yml
+    secrets: inherit
     with:
       os: ${{ inputs.linux }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -165,6 +178,7 @@ jobs:
     if: ${{ always() && inputs.win != '-' }}
     needs: linux-vite
     uses: ./.github/workflows/test-build-vite.yml
+    secrets: inherit
     with:
       os: ${{ inputs.win }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -175,6 +189,7 @@ jobs:
     if: ${{ always() && inputs.mac != '-' }}
     needs: win-vite
     uses: ./.github/workflows/test-build-vite.yml
+    secrets: inherit
     with:
       os: ${{ inputs.mac }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -185,6 +200,7 @@ jobs:
     name: "Ubuntu: React Vite"
     if: ${{ always() && inputs.linux != '-' }}
     uses: ./.github/workflows/test-build-react-vite.yml
+    secrets: inherit
     with:
       os: ${{ inputs.linux }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -195,6 +211,7 @@ jobs:
     if: ${{ always() && inputs.win != '-' }}
     needs: linux-react-vite
     uses: ./.github/workflows/test-build-react-vite.yml
+    secrets: inherit
     with:
       os: ${{ inputs.win }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -205,6 +222,7 @@ jobs:
     if: ${{ always() && inputs.mac != '-' }}
     needs: win-react-vite
     uses: ./.github/workflows/test-build-react-vite.yml
+    secrets: inherit
     with:
       os: ${{ inputs.mac }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -215,6 +233,7 @@ jobs:
     name: "Ubuntu: Vue Vite"
     if: ${{ always() && inputs.linux != '-' }}
     uses: ./.github/workflows/test-build-vue-vite.yml
+    secrets: inherit
     with:
       os: ${{ inputs.linux }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -225,6 +244,7 @@ jobs:
     if: ${{ always() && inputs.win != '-' }}
     needs: linux-vue-vite
     uses: ./.github/workflows/test-build-vue-vite.yml
+    secrets: inherit
     with:
       os: ${{ inputs.win }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -235,6 +255,7 @@ jobs:
     if: ${{ always() && inputs.mac != '-' }}
     needs: win-vue-vite
     uses: ./.github/workflows/test-build-vue-vite.yml
+    secrets: inherit
     with:
       os: ${{ inputs.mac }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -245,6 +266,7 @@ jobs:
     name: "Ubuntu: Next"
     if: ${{ always() && inputs.linux != '-' }}
     uses: ./.github/workflows/test-build-next.yml
+    secrets: inherit
     with:
       os: ${{ inputs.linux }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -255,6 +277,7 @@ jobs:
     if: ${{ always() && inputs.win != '-' }}
     needs: linux-next
     uses: ./.github/workflows/test-build-next.yml
+    secrets: inherit
     with:
       os: ${{ inputs.win }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -265,6 +288,7 @@ jobs:
     if: ${{ always() && inputs.mac != '-' }}
     needs: win-next
     uses: ./.github/workflows/test-build-next.yml
+    secrets: inherit
     with:
       os: ${{ inputs.mac }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -275,6 +299,7 @@ jobs:
     name: "Ubuntu: Nuxt"
     if: ${{ always() && inputs.linux != '-' }}
     uses: ./.github/workflows/test-build-nuxt.yml
+    secrets: inherit
     with:
       os: ${{ inputs.linux }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -285,6 +310,7 @@ jobs:
     if: ${{ always() && inputs.win != '-' }}
     needs: linux-nuxt
     uses: ./.github/workflows/test-build-nuxt.yml
+    secrets: inherit
     with:
       os: ${{ inputs.win }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -295,6 +321,7 @@ jobs:
     if: ${{ always() && inputs.mac != '-' }}
     needs: win-nuxt
     uses: ./.github/workflows/test-build-nuxt.yml
+    secrets: inherit
     with:
       os: ${{ inputs.mac }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -305,6 +332,7 @@ jobs:
     name: "Ubuntu: Lit"
     if: ${{ always() && inputs.linux != '-' }}
     uses: ./.github/workflows/test-build-lit-vite.yml
+    secrets: inherit
     with:
       os: ${{ inputs.linux }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -315,6 +343,7 @@ jobs:
     if: ${{ always() && inputs.win != '-' }}
     needs: linux-lit
     uses: ./.github/workflows/test-build-lit-vite.yml
+    secrets: inherit
     with:
       os: ${{ inputs.win }}
       kit-source: ${{ inputs.kit-source || 'npm' }}
@@ -325,6 +354,7 @@ jobs:
     if: ${{ always() && inputs.mac != '-' }}
     needs: win-lit
     uses: ./.github/workflows/test-build-lit-vite.yml
+    secrets: inherit
     with:
       os: ${{ inputs.mac }}
       kit-source: ${{ inputs.kit-source || 'npm' }}

--- a/.github/workflows/test-build-angular.yml
+++ b/.github/workflows/test-build-angular.yml
@@ -8,6 +8,14 @@ on:
         description: 'OS'
         required: true
         type: string
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: string
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
   workflow_dispatch:
     inputs:
       os:
@@ -18,6 +26,17 @@ on:
         - ubuntu-latest
         - windows-latest
         - macos-latest
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: choice
+        options:
+        - npm
+        - github
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
 
 jobs:
   build:
@@ -33,4 +52,6 @@ jobs:
       stack: angular
       version: ${{ matrix.version }}
       node: ${{ (matrix.version >=20 && 22) || (matrix.version >=17 && 18) || 16 }}
+      kit-source: ${{ inputs.kit-source }}
+      kit-version: ${{ inputs.kit-version }}
       features: "Angular render,${{ vars.FEATURES }}"

--- a/.github/workflows/test-build-angular.yml
+++ b/.github/workflows/test-build-angular.yml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         version: [21,20,19,18,17,16,15,14,13,12]
     uses: ./.github/workflows/test-build.yml
+    secrets: inherit
     with:
       os: ${{ inputs.os }}
       stack: angular

--- a/.github/workflows/test-build-lit-vite.yml
+++ b/.github/workflows/test-build-lit-vite.yml
@@ -8,6 +8,14 @@ on:
         description: 'OS'
         required: true
         type: string
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: string
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
   workflow_dispatch:
     inputs:
       os:
@@ -18,6 +26,17 @@ on:
         - ubuntu-latest
         - windows-latest
         - macos-latest
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: choice
+        options:
+        - npm
+        - github
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
 
 jobs:
   lit-vite:
@@ -33,4 +52,6 @@ jobs:
       stack: lit-vite
       version: ${{ matrix.version }}
       node: 20
+      kit-source: ${{ inputs.kit-source }}
+      kit-version: ${{ inputs.kit-version }}
       features: "Lit render,${{ vars.FEATURES }}"

--- a/.github/workflows/test-build-lit-vite.yml
+++ b/.github/workflows/test-build-lit-vite.yml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         version: [3]
     uses: ./.github/workflows/test-build.yml
+    secrets: inherit
     with:
       os: ${{ inputs.os }}
       stack: lit-vite

--- a/.github/workflows/test-build-lit-vite.yml
+++ b/.github/workflows/test-build-lit-vite.yml
@@ -32,5 +32,5 @@ jobs:
       os: ${{ inputs.os }}
       stack: lit-vite
       version: ${{ matrix.version }}
-      node: 18
+      node: 20
       features: "Lit render,${{ vars.FEATURES }}"

--- a/.github/workflows/test-build-next.yml
+++ b/.github/workflows/test-build-next.yml
@@ -26,11 +26,11 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        version: [19]
+        version: [18, 19]
     uses: ./.github/workflows/test-build.yml
     with:
       os: ${{ inputs.os }}
       stack: next
       version: ${{ matrix.version }}
-      node: 20
+      node: ${{ matrix.version == 19 && 20 || 18 }}
       features: "React render,${{ vars.FEATURES }}"

--- a/.github/workflows/test-build-next.yml
+++ b/.github/workflows/test-build-next.yml
@@ -8,6 +8,14 @@ on:
         description: 'OS'
         required: true
         type: string
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: string
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
   workflow_dispatch:
     inputs:
       os:
@@ -18,6 +26,17 @@ on:
         - ubuntu-latest
         - windows-latest
         - macos-latest
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: choice
+        options:
+        - npm
+        - github
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
 
 jobs:
   next:
@@ -33,4 +52,6 @@ jobs:
       stack: next
       version: ${{ matrix.version }}
       node: ${{ matrix.version == 19 && 20 || 18 }}
+      kit-source: ${{ inputs.kit-source }}
+      kit-version: ${{ inputs.kit-version }}
       features: "React render,${{ vars.FEATURES }}"

--- a/.github/workflows/test-build-next.yml
+++ b/.github/workflows/test-build-next.yml
@@ -26,11 +26,11 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        version: [18]
+        version: [19]
     uses: ./.github/workflows/test-build.yml
     with:
       os: ${{ inputs.os }}
       stack: next
       version: ${{ matrix.version }}
-      node: 18
+      node: 20
       features: "React render,${{ vars.FEATURES }}"

--- a/.github/workflows/test-build-next.yml
+++ b/.github/workflows/test-build-next.yml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         version: [18, 19]
     uses: ./.github/workflows/test-build.yml
+    secrets: inherit
     with:
       os: ${{ inputs.os }}
       stack: next

--- a/.github/workflows/test-build-nuxt.yml
+++ b/.github/workflows/test-build-nuxt.yml
@@ -8,6 +8,14 @@ on:
         description: 'OS'
         required: true
         type: string
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: string
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
   workflow_dispatch:
     inputs:
       os:
@@ -18,6 +26,17 @@ on:
         - ubuntu-latest
         - windows-latest
         - macos-latest
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: choice
+        options:
+        - npm
+        - github
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
 
 jobs:
   nuxt:
@@ -33,5 +52,7 @@ jobs:
       stack: nuxt
       version: ${{ matrix.version }}
       node: 20
+      kit-source: ${{ inputs.kit-source }}
+      kit-version: ${{ inputs.kit-version }}
       features: "Vue render,${{ vars.FEATURES }}"
           

--- a/.github/workflows/test-build-nuxt.yml
+++ b/.github/workflows/test-build-nuxt.yml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         version: [3, 4]
     uses: ./.github/workflows/test-build.yml
+    secrets: inherit
     with:
       os: ${{ inputs.os }}
       stack: nuxt

--- a/.github/workflows/test-build-nuxt.yml
+++ b/.github/workflows/test-build-nuxt.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        version: [3]
+        version: [3, 4]
     uses: ./.github/workflows/test-build.yml
     with:
       os: ${{ inputs.os }}

--- a/.github/workflows/test-build-react-vite.yml
+++ b/.github/workflows/test-build-react-vite.yml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         version: [18,17,16]
     uses: ./.github/workflows/test-build.yml
+    secrets: inherit
     with:
       os: ${{ inputs.os }}
       stack: react-vite

--- a/.github/workflows/test-build-react-vite.yml
+++ b/.github/workflows/test-build-react-vite.yml
@@ -8,6 +8,14 @@ on:
         description: 'OS'
         required: true
         type: string
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: string
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
   workflow_dispatch:
     inputs:
       os:
@@ -18,6 +26,17 @@ on:
         - ubuntu-latest
         - windows-latest
         - macos-latest
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: choice
+        options:
+        - npm
+        - github
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
 
 jobs:
   react-vite:
@@ -33,4 +52,6 @@ jobs:
       stack: react-vite
       version: ${{ matrix.version }}
       node: 20
+      kit-source: ${{ inputs.kit-source }}
+      kit-version: ${{ inputs.kit-version }}
       features: "React render,${{ vars.FEATURES }}"

--- a/.github/workflows/test-build-react.yml
+++ b/.github/workflows/test-build-react.yml
@@ -48,6 +48,7 @@ jobs:
       matrix:
         version: [18,17,16]
     uses: ./.github/workflows/test-build.yml
+    secrets: inherit
     with:
       os: ${{ inputs.os }}
       stack: react

--- a/.github/workflows/test-build-react.yml
+++ b/.github/workflows/test-build-react.yml
@@ -8,6 +8,14 @@ on:
         description: 'OS'
         required: true
         type: string
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: string
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
   workflow_dispatch:
     inputs:
       os:
@@ -19,6 +27,17 @@ on:
         - windows-latest
         - macos-latest
         - macos-14
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: choice
+        options:
+        - npm
+        - github
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
 
 jobs:
   react:
@@ -34,4 +53,6 @@ jobs:
       stack: react
       version: ${{ matrix.version }}
       node: 18
+      kit-source: ${{ inputs.kit-source }}
+      kit-version: ${{ inputs.kit-version }}
       features: "React render,${{ vars.FEATURES }}"

--- a/.github/workflows/test-build-svelte.yml
+++ b/.github/workflows/test-build-svelte.yml
@@ -8,6 +8,14 @@ on:
         description: 'OS'
         required: true
         type: string
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: string
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
   workflow_dispatch:
     inputs:
       os:
@@ -18,6 +26,17 @@ on:
         - ubuntu-latest
         - windows-latest
         - macos-latest
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: choice
+        options:
+        - npm
+        - github
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
 
 jobs:
   svelte:
@@ -33,4 +52,6 @@ jobs:
       stack: svelte
       version: ${{ matrix.version }}
       node: 18
+      kit-source: ${{ inputs.kit-source }}
+      kit-version: ${{ inputs.kit-version }}
       features: "Svelte render,${{ vars.FEATURES }}"

--- a/.github/workflows/test-build-svelte.yml
+++ b/.github/workflows/test-build-svelte.yml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         version: [4,3]
     uses: ./.github/workflows/test-build.yml
+    secrets: inherit
     with:
       os: ${{ inputs.os }}
       stack: svelte

--- a/.github/workflows/test-build-vite.yml
+++ b/.github/workflows/test-build-vite.yml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         version: [18, 19]
     uses: ./.github/workflows/test-build.yml
+    secrets: inherit
     with:
       os: ${{ inputs.os }}
       stack: vite

--- a/.github/workflows/test-build-vite.yml
+++ b/.github/workflows/test-build-vite.yml
@@ -8,6 +8,14 @@ on:
         description: 'OS'
         required: true
         type: string
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: string
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
   workflow_dispatch:
     inputs:
       os:
@@ -18,6 +26,17 @@ on:
         - ubuntu-latest
         - windows-latest
         - macos-latest
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: choice
+        options:
+        - npm
+        - github
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
 
 jobs:
   vite:
@@ -33,4 +52,6 @@ jobs:
       stack: vite
       version: ${{ matrix.version }}
       node: 20
+      kit-source: ${{ inputs.kit-source }}
+      kit-version: ${{ inputs.kit-version }}
       features: "React render,${{ vars.FEATURES }}"

--- a/.github/workflows/test-build-vite.yml
+++ b/.github/workflows/test-build-vite.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        version: [18]
+        version: [18, 19]
     uses: ./.github/workflows/test-build.yml
     with:
       os: ${{ inputs.os }}

--- a/.github/workflows/test-build-vue-vite.yml
+++ b/.github/workflows/test-build-vue-vite.yml
@@ -32,5 +32,5 @@ jobs:
       os: ${{ inputs.os }}
       stack: vue-vite
       version: ${{ matrix.version }}
-      node: 18
+      node: 22
       features: "Vue render,${{ vars.FEATURES }}"

--- a/.github/workflows/test-build-vue-vite.yml
+++ b/.github/workflows/test-build-vue-vite.yml
@@ -8,6 +8,14 @@ on:
         description: 'OS'
         required: true
         type: string
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: string
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
   workflow_dispatch:
     inputs:
       os:
@@ -18,6 +26,17 @@ on:
         - ubuntu-latest
         - windows-latest
         - macos-latest
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: choice
+        options:
+        - npm
+        - github
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
 
 jobs:
   vue-vite:
@@ -33,4 +52,6 @@ jobs:
       stack: vue-vite
       version: ${{ matrix.version }}
       node: 22
+      kit-source: ${{ inputs.kit-source }}
+      kit-version: ${{ inputs.kit-version }}
       features: "Vue render,${{ vars.FEATURES }}"

--- a/.github/workflows/test-build-vue-vite.yml
+++ b/.github/workflows/test-build-vue-vite.yml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         version: [3,2]
     uses: ./.github/workflows/test-build.yml
+    secrets: inherit
     with:
       os: ${{ inputs.os }}
       stack: vue-vite

--- a/.github/workflows/test-build-vue.yml
+++ b/.github/workflows/test-build-vue.yml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         version: [3,2]
     uses: ./.github/workflows/test-build.yml
+    secrets: inherit
     with:
       os: ${{ inputs.os }}
       stack: vue

--- a/.github/workflows/test-build-vue.yml
+++ b/.github/workflows/test-build-vue.yml
@@ -8,6 +8,14 @@ on:
         description: 'OS'
         required: true
         type: string
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: string
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
   workflow_dispatch:
     inputs:
       os:
@@ -18,6 +26,17 @@ on:
         - ubuntu-latest
         - windows-latest
         - macos-latest
+      kit-source:
+        description: 'Rete Kit version source (npm or github)'
+        type: choice
+        options:
+        - npm
+        - github
+        default: 'npm'
+      kit-version:
+        description: 'Rete Kit version/reference'
+        type: string
+        default: 'latest'
 
 jobs:
   vue:
@@ -33,4 +52,6 @@ jobs:
       stack: vue
       version: ${{ matrix.version }}
       node: 18
+      kit-source: ${{ inputs.kit-source }}
+      kit-version: ${{ inputs.kit-version }}
       features: "Vue render,${{ vars.FEATURES }}"

--- a/assets/app/stack/nuxt/modules-v4/app.vue
+++ b/assets/app/stack/nuxt/modules-v4/app.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="page">
+    <NuxtWelcome />
+    <ClientOnly>
+      <Rete />
+    </ClientOnly>
+  </div>
+</template>
+
+<script lang="ts">
+import Rete from './components/Rete.vue'
+
+export default {
+  components: {
+    Rete
+  },
+}
+</script>
+
+<style scoped>
+.page :deep(.min-h-screen) {
+  min-height: auto;
+}
+
+.page :deep(.py-14) {
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.page :deep(.grid) {
+  display: none;
+}
+
+.page :deep(footer) {
+  display: none;
+}
+</style>

--- a/assets/app/stack/nuxt/modules-v4/components/Rete.vue
+++ b/assets/app/stack/nuxt/modules-v4/components/Rete.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="rete" ref="rete"></div>
+</template>
+
+<script lang="ts">
+import { createEditor } from '../rete';
+
+export default {
+  async mounted() {
+    await createEditor(this.$refs.rete)
+  }
+}
+</script>
+
+<style scoped>
+@import '../common.css';
+@import '../customization/background.css';
+
+.rete {
+  position: relative;
+  width: 80vw;
+  height: 90vh;
+  font-size: 1rem;
+  background: white;
+  margin: 1em auto 3em auto;
+  border-radius: 1em;
+  text-align: left;
+  border: 3px solid #55b881;
+}
+</style>

--- a/assets/app/stack/react/modules/vite/App.tsx
+++ b/assets/app/stack/react/modules/vite/App.tsx
@@ -1,7 +1,7 @@
 import { useRete } from 'rete-react-plugin';
 import reactLogo from './assets/react.svg'
 import reteLogo from './assets/rete.svg'
-import viteLogo from '/vite.svg'
+import viteLogo from './assets/vite.svg'
 import { createEditor } from './rete';
 import './common.css';
 import './customization/background.css';

--- a/assets/app/stack/vite/modules/main.ts
+++ b/assets/app/stack/vite/modules/main.ts
@@ -3,12 +3,12 @@ import './customization/background.css';
 import './style.css'
 import './rete.css'
 
-import viteLogo from '/vite.svg'
+import viteLogo from './assets/vite.svg'
 import React from 'react'
 
 import reteLogo from './assets/rete.svg'
 import { createEditor } from './rete'
-import typescriptLogo from './typescript.svg'
+import typescriptLogo from './assets/typescript.svg'
 
 window.React = React
 

--- a/src/app/app-builder.ts
+++ b/src/app/app-builder.ts
@@ -7,7 +7,7 @@ export interface AppBuilder {
 
   create(name: string, version: number): Promise<void>
   putAssets<Key extends string>(name: string, version: number, templateBuilder: TemplateBuilder<Key>): Promise<void>
-  putScript(name: string, path: string, code: string): Promise<void>
+  putScript(name: string, path: string, code: string, version: number): Promise<void>
   getStaticPath(name: string, version?: number): string
   getBuildCommand(version: number): string
 }

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -71,8 +71,8 @@ export async function createApp({ name, stack, version, features, depsAlias, for
     new Features.React(builder.foundation === 'react'
       ? selectedVersion
       : 18, selectedStack, next),
-    new Features.Vue(builder.foundation === 'vue'
-      ? selectedVersion as 2
+    new Features.Vue(builder instanceof VueBuilder
+      ? selectedVersion as 2 | 3
       : 3, next),
     new Features.Svelte(builder.foundation === 'svelte'
       ? selectedVersion as SvelteVersion

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -71,7 +71,7 @@ export async function createApp({ name, stack, version, features, depsAlias, for
     new Features.React(builder.foundation === 'react'
       ? selectedVersion
       : 18, selectedStack, next),
-    new Features.Vue(builder instanceof VueBuilder
+    new Features.Vue(builder.foundation === 'vue' && !(builder instanceof NuxtBuilder)
       ? selectedVersion as 2 | 3
       : 3, next),
     new Features.Svelte(builder.foundation === 'svelte'

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -127,13 +127,13 @@ export async function createApp({ name, stack, version, features, depsAlias, for
     try {
       const code = await templateBuilder.build(template)
 
-      await builder.putScript(appName, `${templateName}.ts`, code)
+      await builder.putScript(appName, `${templateName}.ts`, code, selectedVersion)
     } catch (e) {
       console.error(e)
       throwError(`failed to build template "${templateName}"`)
     }
   }
-  await builder.putScript(appName, `index.ts`, await templateBuilder.getEntryScript())
+  await builder.putScript(appName, `index.ts`, await templateBuilder.getEntryScript(), selectedVersion)
 
   await install(appName, Features.getDependencies(activeFeatures), depsAlias, forceInstall)
 }

--- a/src/app/stack/lit/vite.ts
+++ b/src/app/stack/lit/vite.ts
@@ -13,7 +13,7 @@ export class LitViteBuilder implements AppBuilder {
 
   public async create(name: string, version: number) {
     await execa('npm', [
-      'create', 'vite@7', name, '--', '--template', 'vanilla-ts', '-y'
+      'create', 'vite@9', name, '--', '--template', 'vanilla-ts', '-y'
     ], { stdio: 'inherit' })
     await execa('npm', [
       'i',

--- a/src/app/stack/next/index.ts
+++ b/src/app/stack/next/index.ts
@@ -8,17 +8,32 @@ import { assetsCommon, assetsStack } from '../../consts'
 
 export class NextBuilder implements AppBuilder {
   public name = 'Next.js'
-  public versions = [19]
+  public versions = [18, 19]
   public foundation = 'react' as const
 
   public async create(name: string, version: number) {
-    if (version !== 19) throw new Error('Unsupported version')
+    if (version === 18) {
+      await execa('npx', [
+        'create-next-app@14', name,
+        '--ts', '--src-dir', '--no-eslint', '--no-tailwind', '--app', '--import-alias', '@/*'
+      ], { stdio: 'inherit' })
 
-    await execa('npx', [
-      'create-next-app@16', name,
-      '--ts', '--src-dir', '--no-linter', '--no-agents-md', '--use-npm', '--yes',
-      '--app', '--import-alias', '@/*', '--no-tailwind'
-    ], { stdio: 'inherit' })
+      const eslintConfigName = '.eslintrc.json'
+
+      await fse.copy(join(assetsStack, 'next', eslintConfigName), join(name, eslintConfigName), { overwrite: true })
+      return
+    }
+
+    if (version === 19) {
+      await execa('npx', [
+        'create-next-app@16', name,
+        '--ts', '--src-dir', '--no-linter', '--no-agents-md', '--use-npm', '--yes',
+        '--app', '--import-alias', '@/*', '--no-tailwind'
+      ], { stdio: 'inherit' })
+      return
+    }
+
+    throw new Error('Unsupported version')
   }
 
   async putAssets(name: string) {

--- a/src/app/stack/next/index.ts
+++ b/src/app/stack/next/index.ts
@@ -8,20 +8,17 @@ import { assetsCommon, assetsStack } from '../../consts'
 
 export class NextBuilder implements AppBuilder {
   public name = 'Next.js'
-  public versions = [18]
+  public versions = [19]
   public foundation = 'react' as const
 
   public async create(name: string, version: number) {
-    if (version !== 18) throw new Error('Unsupported version')
+    if (version !== 19) throw new Error('Unsupported version')
 
-    const createNextVersion = 14
-
-    await execa('npx', [`create-next-app@${createNextVersion}`, name,
-      '--ts', '--src-dir', '--no-eslint', '--no-tailwind', '--app', '--import-alias', '@/*'], { stdio: 'inherit' })
-
-    const eslintConfigName = '.eslintrc.json'
-
-    await fse.copy(join(assetsStack, 'next', eslintConfigName), join(name, eslintConfigName), { overwrite: true })
+    await execa('npx', [
+      'create-next-app@16', name,
+      '--ts', '--src-dir', '--no-linter', '--no-agents-md', '--use-npm', '--yes',
+      '--app', '--import-alias', '@/*', '--no-tailwind'
+    ], { stdio: 'inherit' })
   }
 
   async putAssets(name: string) {

--- a/src/app/stack/nuxt/index.ts
+++ b/src/app/stack/nuxt/index.ts
@@ -10,18 +10,29 @@ import { templateAssets } from '../vue/helpers'
 
 export class NuxtBuilder implements AppBuilder {
   public name = 'Nuxt'
-  public versions = [3]
+  public versions = [3, 4]
   public foundation = 'vue' as const
+  private appVersion = 3
 
-  public async create(name: string) {
-    await execa('npx', ['nuxi@3', 'init', name, '--template', 'v3', '--packageManager', 'npm', '--gitInit'], { stdio: 'inherit' })
+  public async create(name: string, version: number) {
+    const template = version === 4 ? 'v4' : 'v3'
+
+    await execa('npx', [
+      'nuxi@3', 'init', name, '--template', template,
+      '--packageManager', 'npm', '--gitInit'
+    ], { stdio: 'inherit' })
+  }
+
+  private getAppRoot(name: string, version: number) {
+    return version === 4 ? join(name, 'app') : name
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  async putAssets<K extends string>(name: string, _version: number, template: TemplateBuilder<K>): Promise<void> {
-    const modules = join(assetsStack, 'nuxt', 'modules')
+  async putAssets<K extends string>(name: string, version: number, template: TemplateBuilder<K>): Promise<void> {
+    this.appVersion = version
+    const modules = join(assetsStack, 'nuxt', version === 4 ? 'modules-v4' : 'modules')
     const customization = join(assetsStack, 'vue', 'modules', 'vite', 'customization')
-    const src = join(name)
+    const src = this.getAppRoot(name, version)
 
     await fse.copy(assetsCommon, src, {
       recursive: true,
@@ -39,7 +50,8 @@ export class NuxtBuilder implements AppBuilder {
   }
 
   async putScript(name: string, path: string, code: string) {
-    const scriptPath = join(name, 'rete', path)
+    const reteRoot = this.appVersion === 4 ? join(name, 'app', 'rete') : join(name, 'rete')
+    const scriptPath = join(reteRoot, path)
 
     await fs.promises.mkdir(dirname(scriptPath), { recursive: true })
     await fs.promises.writeFile(scriptPath, code)

--- a/src/app/stack/nuxt/index.ts
+++ b/src/app/stack/nuxt/index.ts
@@ -12,10 +12,11 @@ export class NuxtBuilder implements AppBuilder {
   public name = 'Nuxt'
   public versions = [3, 4]
   public foundation = 'vue' as const
-  private appVersion = 3
 
   public async create(name: string, version: number) {
-    const template = version === 4 ? 'v4' : 'v3'
+    const template = version === 4
+      ? 'v4'
+      : 'v3'
 
     await execa('npx', [
       'nuxi@3', 'init', name, '--template', template,
@@ -24,13 +25,15 @@ export class NuxtBuilder implements AppBuilder {
   }
 
   private getAppRoot(name: string, version: number) {
-    return version === 4 ? join(name, 'app') : name
+    return version === 4
+      ? join(name, 'app')
+      : name
   }
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   async putAssets<K extends string>(name: string, version: number, template: TemplateBuilder<K>): Promise<void> {
-    this.appVersion = version
-    const modules = join(assetsStack, 'nuxt', version === 4 ? 'modules-v4' : 'modules')
+    const modules = join(assetsStack, 'nuxt', version === 4
+      ? 'modules-v4'
+      : 'modules')
     const customization = join(assetsStack, 'vue', 'modules', 'vite', 'customization')
     const src = this.getAppRoot(name, version)
 
@@ -49,8 +52,10 @@ export class NuxtBuilder implements AppBuilder {
     await templateAssets(src, template)
   }
 
-  async putScript(name: string, path: string, code: string) {
-    const reteRoot = this.appVersion === 4 ? join(name, 'app', 'rete') : join(name, 'rete')
+  async putScript(name: string, path: string, code: string, version: number) {
+    const reteRoot = version === 4
+      ? join(name, 'app', 'rete')
+      : join(name, 'rete')
     const scriptPath = join(reteRoot, path)
 
     await fs.promises.mkdir(dirname(scriptPath), { recursive: true })

--- a/src/app/stack/nuxt/index.ts
+++ b/src/app/stack/nuxt/index.ts
@@ -53,9 +53,7 @@ export class NuxtBuilder implements AppBuilder {
   }
 
   async putScript(name: string, path: string, code: string, version: number) {
-    const reteRoot = version === 4
-      ? join(name, 'app', 'rete')
-      : join(name, 'rete')
+    const reteRoot = join(this.getAppRoot(name, version), 'rete')
     const scriptPath = join(reteRoot, path)
 
     await fs.promises.mkdir(dirname(scriptPath), { recursive: true })

--- a/src/app/stack/react/vite.ts
+++ b/src/app/stack/react/vite.ts
@@ -12,7 +12,7 @@ export class ReactViteBuilder implements AppBuilder {
   public foundation = 'react' as const
 
   public async create(name: string, version: number) {
-    await execa('npm', ['create', 'vite@7', name, '--', '--template', 'react-ts'], { stdio: 'inherit' })
+    await execa('npm', ['create', 'vite@9', name, '--', '--template', 'react-ts'], { stdio: 'inherit' })
     await execa('npm', [
       'i',
       `react@${version}`,

--- a/src/app/stack/vite/index.ts
+++ b/src/app/stack/vite/index.ts
@@ -9,12 +9,12 @@ import { assetsCommon, assetsStack } from '../../consts'
 
 export class ViteBuilder implements AppBuilder {
   public name = 'Vite'
-  public versions = [16, 17, 18]
+  public versions = [16, 17, 18, 19]
   public foundation = 'react' as const
 
   public async create(name: string) {
     await execa('npm', [
-      'create', 'vite@7', name, '--', '--template', 'vanilla-ts', '-y'
+      'create', 'vite@9', name, '--', '--template', 'vanilla-ts', '-y'
     ], { stdio: 'inherit' })
     await execa('npm', ['i'], { cwd: join(process.cwd(), name), stdio: 'inherit' })
 

--- a/src/app/stack/vue/legacy.ts
+++ b/src/app/stack/vue/legacy.ts
@@ -20,7 +20,7 @@ export class VueBuilder implements AppBuilder {
       : 'vue3')
 
     await execa('npx', [
-      '--package', `@vue/cli@`, 'vue', 'create', name,
+      '--package', `@vue/cli@5`, 'vue', 'create', name,
       '--preset', presetFolder,
       '-m', 'npm',
       '-r', 'https://registry.npmjs.org'


### PR DESCRIPTION
### Description

Updates rete-kit app scaffolds and CI matrices to current major ecosystem tooling, building on the regression fixes merged in #72.

**Vue (legacy)** — pin `@vue/cli@5` instead of floating `@vue/cli@`.

**Vite stacks** (`vite`, `react-vite`, `lit-vite`) — upgrade scaffold to `create-vite@9` (generates Vite 8 apps). Fix SVG import paths for the new template layout. Add React 19 to the vite stack matrix; run lit-vite CI on Node 20.

**Nuxt** — add version `4` alongside `3` (`nuxi` templates `v3` / `v4`). Add `modules-v4/` assets for the Nuxt 4 `app/` directory layout. Pass `version` explicitly to `putScript` (no mutable state on singleton builders). Fix `Features.Vue`: use stack version for `vue` / `vue-vite`, always Vue 3 for `nuxt` (where `version` is the Nuxt major).

**Next.js** — support React **18** and **19**:
- React 18 → `create-next-app@14` (Next 14), CI Node 18
- React 19 → `create-next-app@16` (Next 16), CI Node 20

**Vue Vite** — CI Node 18 → 22 (`create-vue@3` requires Node ^22.18).

**Not in scope:** Angular 22 (no `rete-angular-plugin/22`), CRA (deprecated).

Tested locally on Linux/WSL (`rete-kit app` → `npm install` → `npm run build` / `generate`): vue v3, vite v18, lit-vite v3, nuxt v3/v4, next v18/v19, vue-vite v2/v3 — all passed.

### Related Issues

Follow-up to regression build failures addressed in #72.

### Checklist

- [x] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://retejs.org/docs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).