### PR TITLE
feat(angular): add support for angular 22

### DIFF
--- a/.github/workflows/test-build-angular.yml
+++ b/.github/workflows/test-build-angular.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        version: [21,20,19,18,17,16,15,14,13,12]
+        version: [22,21,20,19,18,17,16,15,14,13,12]
     uses: ./.github/workflows/test-build.yml
     secrets: inherit
     with:

--- a/assets/app/stack/angular/modules/app/app.component.ts
+++ b/assets/app/stack/angular/modules/app/app.component.ts
@@ -15,6 +15,7 @@ import { createEditor } from './rete'
     /* [angular19] './app.component.html', [/angular19] */
     /* [angular20] './app.html', [/angular20] */
     /* [angular21] './app.html', [/angular21] */
+    /* [angular22] './app.html', [/angular22] */
   styleUrls: [
     /* [angular12] './app.component.css', [/angular12] */
     /* [angular13] './app.component.css', [/angular13] */
@@ -26,10 +27,11 @@ import { createEditor } from './rete'
     /* [angular19] './app.component.css', [/angular19] */
     /* [angular20] './app.css', [/angular20] */
     /* [angular21] './app.css', [/angular21] */
+    /* [angular22] './app.css', [/angular22] */
     './common.css'
   ]
 })
-export class /* [angular12] AppComponent [/angular12] *//* [angular13] AppComponent [/angular13] *//* [angular14] AppComponent [/angular14] *//* [angular15] AppComponent [/angular15] *//* [angular16] AppComponent [/angular16] *//* [angular17] AppComponent [/angular17] *//* [angular18] AppComponent [/angular18] *//* [angular19] AppComponent [/angular19] *//* [angular20] App [/angular20] *//* [angular21] App [/angular21] */ implements AfterViewInit {
+export class /* [angular12] AppComponent [/angular12] *//* [angular13] AppComponent [/angular13] *//* [angular14] AppComponent [/angular14] *//* [angular15] AppComponent [/angular15] *//* [angular16] AppComponent [/angular16] *//* [angular17] AppComponent [/angular17] *//* [angular18] AppComponent [/angular18] *//* [angular19] AppComponent [/angular19] *//* [angular20] App [/angular20] *//* [angular21] App [/angular21] *//* [angular22] App [/angular22] */ implements AfterViewInit {
   title = 'angular'
   @ViewChild('rete') container!: ElementRef<HTMLElement>
 

--- a/assets/app/stack/angular/modules/app/app.module.ts
+++ b/assets/app/stack/angular/modules/app/app.module.ts
@@ -11,6 +11,7 @@ import { BrowserModule } from '@angular/platform-browser';
 /* [angular19] import { AppComponent } from './app.component'; [/angular19] */
 /* [angular20] import { App } from './app'; [/angular20] */
 /* [angular21] import { App } from './app'; [/angular21] */
+/* [angular22] import { App } from './app'; [/angular22] */
 /* [angular12]
 import { CustomSocketComponent } from "./customization/custom-socket/custom-socket.component"
 import { CustomNodeComponent } from "./customization/custom-node/custom-node.component"
@@ -61,6 +62,7 @@ import { CustomConnectionComponent } from "./customization/custom-connection/cus
 /* [angular19] import { ReteModule } from 'rete-angular-plugin/19'; [/angular19] */
 /* [angular20] import { ReteModule } from 'rete-angular-plugin/20'; [/angular20] */
 /* [angular21] import { ReteModule } from 'rete-angular-plugin/21'; [/angular21] */
+/* [angular22] import { ReteModule } from 'rete-angular-plugin/22'; [/angular22] */
 
 @NgModule({
   declarations: [
@@ -129,6 +131,7 @@ import { CustomConnectionComponent } from "./customization/custom-connection/cus
     /* [angular19] AppComponent [/angular19] */
     /* [angular20] App [/angular20] */
     /* [angular21] App [/angular21] */
+    /* [angular22] App [/angular22] */
   ]
 })
 export class AppModule { }

--- a/assets/app/stack/angular/modules/app/customization/custom-node/custom-node.component.ts
+++ b/assets/app/stack/angular/modules/app/customization/custom-node/custom-node.component.ts
@@ -18,11 +18,16 @@ import { RefDirective, ImpureKeyvaluePipe } from 'rete-angular-plugin/20';
 import { CommonModule } from '@angular/common';
 import { RefDirective, ImpureKeyvaluePipe } from 'rete-angular-plugin/21';
 [/angular21] */
+/* [angular22]
+import { CommonModule } from '@angular/common';
+import { RefDirective, ImpureKeyvaluePipe } from 'rete-angular-plugin/22';
+[/angular22] */
 
 @Component({
   /* [angular19] imports: [CommonModule, RefDirective, ImpureKeyvaluePipe], [/angular19] */
   /* [angular20] imports: [CommonModule, RefDirective, ImpureKeyvaluePipe], [/angular20] */
   /* [angular21] imports: [CommonModule, RefDirective, ImpureKeyvaluePipe], [/angular21] */
+  /* [angular22] imports: [CommonModule, RefDirective, ImpureKeyvaluePipe], [/angular22] */
   templateUrl: "./custom-node.component.html",
   styleUrls: ["./custom-node.component.sass"],
   host: {

--- a/assets/app/templates/3d
+++ b/assets/app/templates/3d
@@ -7,7 +7,7 @@ import { ConnectionPlugin, Presets as ConnectionPresets } from 'rete-connection-
 /* [react18] import { createRoot } from 'react-dom/client' [/react18] */
 /* [react19] import { createRoot } from 'react-dom/client' [/react19] */
 /* [vue-render] import { VuePlugin, type VueArea2D, Presets as VuePresets } from 'rete-vue-plugin/* [vue2] /vue2 [/vue2] */' [/vue-render] */
-/* [angular-render] import { AngularPlugin, type AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/* [angular12] /12 [/angular12] *//* [angular13] /13 [/angular13] *//* [angular14] /14 [/angular14] *//* [angular15] /15 [/angular15] *//* [angular16] /16 [/angular16] *//* [angular17] /17 [/angular17] *//* [angular18] /18 [/angular18] *//* [angular19] /19 [/angular19] *//* [angular20] /20 [/angular20] *//* [angular21] /21 [/angular21] */' [/angular-render] */
+/* [angular-render] import { AngularPlugin, type AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/* [angular12] /12 [/angular12] *//* [angular13] /13 [/angular13] *//* [angular14] /14 [/angular14] *//* [angular15] /15 [/angular15] *//* [angular16] /16 [/angular16] *//* [angular17] /17 [/angular17] *//* [angular18] /18 [/angular18] *//* [angular19] /19 [/angular19] *//* [angular20] /20 [/angular20] *//* [angular21] /21 [/angular21] *//* [angular22] /22 [/angular22] */' [/angular-render] */
 /* [svelte-render] import { SveltePlugin, type SvelteArea2D, Presets as SveltePresets } from 'rete-svelte-plugin/* [svelte5] /5 [/svelte5] */' [/svelte-render] */
 /* [lit-render] import { LitPlugin, type LitArea2D, Presets as LitPresets } from '@retejs/lit-plugin' [/lit-render] */
 /* [dataflow] import { DataflowEngine, type DataflowNode } from 'rete-engine' [/dataflow] */

--- a/assets/app/templates/customization
+++ b/assets/app/templates/customization
@@ -9,7 +9,7 @@ import {
 /* [react18] import { createRoot } from 'react-dom/client' [/react18] */
 /* [react19] import { createRoot } from 'react-dom/client' [/react19] */
 /* [stack-vue] import { VuePlugin, type VueArea2D, Presets as VuePresets } from 'rete-vue-plugin/* [vue2] /vue2 [/vue2] */' [/stack-vue] */
-/* [stack-angular] import { AngularPlugin, type AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/* [angular12] /12 [/angular12] *//* [angular13] /13 [/angular13] *//* [angular14] /14 [/angular14] *//* [angular15] /15 [/angular15] *//* [angular16] /16 [/angular16] *//* [angular17] /17 [/angular17] *//* [angular18] /18 [/angular18] *//* [angular19] /19 [/angular19] *//* [angular20] /20 [/angular20] *//* [angular21] /21 [/angular21] */' [/stack-angular] */
+/* [stack-angular] import { AngularPlugin, type AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/* [angular12] /12 [/angular12] *//* [angular13] /13 [/angular13] *//* [angular14] /14 [/angular14] *//* [angular15] /15 [/angular15] *//* [angular16] /16 [/angular16] *//* [angular17] /17 [/angular17] *//* [angular18] /18 [/angular18] *//* [angular19] /19 [/angular19] *//* [angular20] /20 [/angular20] *//* [angular21] /21 [/angular21] *//* [angular22] /22 [/angular22] */' [/stack-angular] */
 /* [stack-svelte] import { SveltePlugin, type SvelteArea2D, Presets as SveltePresets } from 'rete-svelte-plugin/* [svelte5] /5 [/svelte5] */' [/stack-svelte] */
 /* [stack-lit] import { LitPlugin, type LitArea2D, Presets as LitPresets } from '@retejs/lit-plugin' [/stack-lit] */
 /* [stack-react] import { CustomNode } from "../customization/CustomNode";

--- a/assets/app/templates/default
+++ b/assets/app/templates/default
@@ -6,7 +6,7 @@ import { type Area2D, /* [import-area-extensions] AreaExtensions, [/import-area-
 /* [react18] import { createRoot } from 'react-dom/client' [/react18] */
 /* [react19] import { createRoot } from 'react-dom/client' [/react19] */
 /* [vue-render] import { VuePlugin, type VueArea2D, Presets as VuePresets } from 'rete-vue-plugin/* [vue2] /vue2 [/vue2] */' [/vue-render] */
-/* [angular-render] import { AngularPlugin, type AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/* [angular12] /12 [/angular12] *//* [angular13] /13 [/angular13] *//* [angular14] /14 [/angular14] *//* [angular15] /15 [/angular15] *//* [angular16] /16 [/angular16] *//* [angular17] /17 [/angular17] *//* [angular18] /18 [/angular18] *//* [angular19] /19 [/angular19] *//* [angular20] /20 [/angular20] *//* [angular21] /21 [/angular21] */' [/angular-render] */
+/* [angular-render] import { AngularPlugin, type AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/* [angular12] /12 [/angular12] *//* [angular13] /13 [/angular13] *//* [angular14] /14 [/angular14] *//* [angular15] /15 [/angular15] *//* [angular16] /16 [/angular16] *//* [angular17] /17 [/angular17] *//* [angular18] /18 [/angular18] *//* [angular19] /19 [/angular19] *//* [angular20] /20 [/angular20] *//* [angular21] /21 [/angular21] *//* [angular22] /22 [/angular22] */' [/angular-render] */
 /* [svelte-render] import { SveltePlugin, type SvelteArea2D, Presets as SveltePresets } from 'rete-svelte-plugin/* [svelte5] /5 [/svelte5] */' [/svelte-render] */
 /* [lit-render] import { LitPlugin, type LitArea2D, Presets as LitPresets } from '@retejs/lit-plugin' [/lit-render] */
 /* [dataflow] import { DataflowEngine, type DataflowNode } from 'rete-engine' [/dataflow] */

--- a/assets/app/templates/perf
+++ b/assets/app/templates/perf
@@ -5,7 +5,7 @@ import { /* [import-area-extensions] AreaExtensions, [/import-area-extensions] *
 /* [react18] import { createRoot } from 'react-dom/client' [/react18] */
 /* [react19] import { createRoot } from 'react-dom/client' [/react19] */
 /* [vue-render] import { VuePlugin, type VueArea2D, Presets as VuePresets } from 'rete-vue-plugin/* [vue2] /vue2 [/vue2] */' [/vue-render] */
-/* [angular-render] import { AngularPlugin, type AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/* [angular12] /12 [/angular12] *//* [angular13] /13 [/angular13] *//* [angular14] /14 [/angular14] *//* [angular15] /15 [/angular15] *//* [angular16] /16 [/angular16] *//* [angular17] /17 [/angular17] *//* [angular18] /18 [/angular18] *//* [angular19] /19 [/angular19] *//* [angular20] /20 [/angular20] *//* [angular21] /21 [/angular21] */' [/angular-render] */
+/* [angular-render] import { AngularPlugin, type AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/* [angular12] /12 [/angular12] *//* [angular13] /13 [/angular13] *//* [angular14] /14 [/angular14] *//* [angular15] /15 [/angular15] *//* [angular16] /16 [/angular16] *//* [angular17] /17 [/angular17] *//* [angular18] /18 [/angular18] *//* [angular19] /19 [/angular19] *//* [angular20] /20 [/angular20] *//* [angular21] /21 [/angular21] *//* [angular22] /22 [/angular22] */' [/angular-render] */
 /* [svelte-render] import { SveltePlugin, type SvelteArea2D, Presets as SveltePresets } from 'rete-svelte-plugin/* [svelte5] /5 [/svelte5] */' [/svelte-render] */
 /* [lit-render] import { LitPlugin, type LitArea2D, Presets as LitPresets } from '@retejs/lit-plugin' [/lit-render] */
 

--- a/assets/app/templates/scopes
+++ b/assets/app/templates/scopes
@@ -6,7 +6,7 @@ import { type Area2D, /* [import-area-extensions] AreaExtensions, [/import-area-
 /* [react18] import { createRoot } from 'react-dom/client' [/react18] */
 /* [react19] import { createRoot } from 'react-dom/client' [/react19] */
 /* [vue-render] import { VuePlugin, type VueArea2D, Presets as VuePresets } from 'rete-vue-plugin/* [vue2] /vue2 [/vue2] */' [/vue-render] */
-/* [angular-render] import { AngularPlugin, type AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/* [angular12] /12 [/angular12] *//* [angular13] /13 [/angular13] *//* [angular14] /14 [/angular14] *//* [angular15] /15 [/angular15] *//* [angular16] /16 [/angular16] *//* [angular17] /17 [/angular17] *//* [angular18] /18 [/angular18] *//* [angular19] /19 [/angular19] *//* [angular20] /20 [/angular20] *//* [angular21] /21 [/angular21] */' [/angular-render] */
+/* [angular-render] import { AngularPlugin, type AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/* [angular12] /12 [/angular12] *//* [angular13] /13 [/angular13] *//* [angular14] /14 [/angular14] *//* [angular15] /15 [/angular15] *//* [angular16] /16 [/angular16] *//* [angular17] /17 [/angular17] *//* [angular18] /18 [/angular18] *//* [angular19] /19 [/angular19] *//* [angular20] /20 [/angular20] *//* [angular21] /21 [/angular21] *//* [angular22] /22 [/angular22] */' [/angular-render] */
 /* [svelte-render] import { SveltePlugin, type SvelteArea2D, Presets as SveltePresets } from 'rete-svelte-plugin/* [svelte5] /5 [/svelte5] */' [/svelte-render] */
 /* [lit-render] import { LitPlugin, type LitArea2D, Presets as LitPresets } from '@retejs/lit-plugin' [/lit-render] */
 import { ScopesPlugin, Presets as ScopesPresets } from "rete-scopes-plugin";

--- a/src/app/stack/angular/index.ts
+++ b/src/app/stack/angular/index.ts
@@ -17,7 +17,7 @@ export type {
 
 export class AngularBuilder implements AppBuilder {
   public name = 'Angular'
-  public versions: AngularVersion[] = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+  public versions: AngularVersion[] = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
   public foundation = 'angular' as const
 
   public async create(name: string, version: number) {
@@ -84,7 +84,7 @@ export class AngularBuilder implements AppBuilder {
   }
 
   getStaticPath(name: string, version?: number) {
-    if (version && [17, 18, 19, 20, 21].includes(version)) return join('dist', name, 'browser')
+    if (version && [17, 18, 19, 20, 21, 22].includes(version)) return join('dist', name, 'browser')
     return join('dist', name)
   }
 

--- a/src/app/stack/angular/types.ts
+++ b/src/app/stack/angular/types.ts
@@ -1,6 +1,6 @@
 import type { TSConfig } from '../../../shared/ts-config'
 
-export type AngularVersion = 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21
+export type AngularVersion = 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22
 
 export interface AngularTSConfig extends TSConfig {
   angularCompilerOptions: {


### PR DESCRIPTION
### Description

Adds **Angular 22** support.

- Extend `AngularVersion` and `AngularBuilder` supported versions (12–22)
- Add `[angular22]` conditional blocks in templates (`default`, `customization`, `3d`, `perf`, `scopes`) and Angular app modules
- Import `rete-angular-plugin/22` for Angular 22
- Angular 22 uses the same output layout as 17–21 (`dist/<name>/browser`)
- CI: add Angular 22 to the matrix in `test-build-angular.yml`

> **Dependency:** requires a `rete-angular-plugin` release with `/22` support.

### Related Issues

https://github.com/retejs/angular-plugin/pull/374

### Checklist

- [x] I have read and followed the contribution guidelines.
- [x] I have tested my changes locally.
- [ ] I have updated documentation accordingly (if necessary).