### PR TITLE
feat(app): add History and Comments features with template integration

### DIFF
--- a/assets/app/templates/default
+++ b/assets/app/templates/default
@@ -263,7 +263,7 @@ await area.nodeViews.get(add.id)?.translate(400, 150)
 const addPos = area.nodeViews.get(add.id)!.position
 
 comment.addFrame('Frame comment — drag nodes in/out', [a.id, b.id])
-comment.addInline(/* [history] 'Inline comment — try Ctrl+Z after edit/delete' [/history] *//* [!history] 'Inline comment' [/!history] */, [addPos.x + 30, addPos.y - 30], add.id)
+comment.addInline(/* [history] 'Inline comment — try Ctrl+Z after edit/delete' [/history] *//* [!history] 'Inline comment' [/!history] */, [addPos.x + 40, addPos.y - 30], add.id)
 [/comments] */
 [/!arrange] */
 
@@ -279,7 +279,7 @@ await arrange.layout()
 const addPos = area.nodeViews.get(add.id)!.position
 
 comment.addFrame('Frame comment — drag nodes in/out', [a.id, b.id])
-comment.addInline(/* [history] 'Inline comment — try Ctrl+Z after edit/delete' [/history] *//* [!history] 'Inline comment' [/!history] */, [addPos.x - 60, addPos.y - 62], add.id)
+comment.addInline(/* [history] 'Inline comment — try Ctrl+Z after edit/delete' [/history] *//* [!history] 'Inline comment' [/!history] */, [addPos.x + 40, addPos.y - 30], add.id)
 [/comments] */
 [/arrange] */
 

--- a/assets/app/templates/default
+++ b/assets/app/templates/default
@@ -14,6 +14,14 @@ import { type Area2D, /* [import-area-extensions] AreaExtensions, [/import-area-
 /* [readonly] import { ReadonlyPlugin } from 'rete-readonly-plugin' [/readonly] */
 /* [context-menu] import { ContextMenuPlugin, type ContextMenuExtra, Presets as ContextMenuPresets } from 'rete-context-menu-plugin' [/context-menu] */
 /* [minimap] import { type MinimapExtra, MinimapPlugin } from 'rete-minimap-plugin'; [/minimap] */
+/* [comments] import { CommentPlugin /* [selectable] , CommentExtensions [/selectable] */ } from 'rete-comment-plugin' [/comments] */
+/* [history] import {
+  /* [comments] type CommentHistoryActions, [/comments] */
+  type HistoryActions,
+  HistoryExtensions,
+  HistoryPlugin,
+  Presets as HistoryPresets
+} from 'rete-history-plugin' [/history] */
 /* [reroute] import { ReroutePlugin, type RerouteExtra /* [selectable] , RerouteExtensions [/selectable] */ } from "rete-connection-reroute-plugin";[/reroute] */
 
 type Node =
@@ -109,6 +117,8 @@ export async function createEditor(container: HTMLElement/* [stack-angular] , in
     ])
 })[/context-menu] */
   /* [minimap] const minimap = new MinimapPlugin<Schemes>(); [/minimap] */
+  /* [comments] const comment = new CommentPlugin<Schemes, AreaExtra>() [/comments] */
+  /* [history] const history = new HistoryPlugin<Schemes, /* [comments] HistoryActions<Schemes> | CommentHistoryActions [/comments] *//* [!comments] HistoryActions<Schemes> [/!comments] */>() [/history] */
   /* [reroute] const reroutePlugin = new ReroutePlugin<Schemes>(); [/reroute] */
 
   /* [readonly] editor.use(readonly.root) [/readonly] */
@@ -122,6 +132,8 @@ export async function createEditor(container: HTMLElement/* [stack-angular] , in
   /* [!readonly] area.use(connection) [/!readonly] */
   /* [context-menu] area.use(contextMenu) [/context-menu] */
   /* [minimap] area.use(minimap) [/minimap] */
+  /* [comments] area.use(comment) [/comments] */
+  /* [history] area.use(history) [/history] */
   /* [reroute]
   /* [react-render] reactRender.use(reroutePlugin) [/react-render] */
   /* [vue-render] vueRender.use(reroutePlugin) [/vue-render] */
@@ -222,6 +234,11 @@ export async function createEditor(container: HTMLElement/* [stack-angular] , in
     } [/selectable] */
   }));[/reroute] */
   [/lit-render] */
+  /* [history]
+  history.addPreset(HistoryPresets.classic.setup())
+  /* [comments] history.addPreset(HistoryPresets.comments.setup({ comment })) [/comments] */
+  HistoryExtensions.keyboard(history)
+  [/history] */
   /* [dataflow] const dataflow = new DataflowEngine<Schemes>()
 
   editor.use(dataflow)
@@ -242,6 +259,12 @@ await editor.addConnection(new Connection(b, 'value', add, 'b'))
 await area.nodeViews.get(a.id)?.translate(100, 100)
 await area.nodeViews.get(b.id)?.translate(100, 300)
 await area.nodeViews.get(add.id)?.translate(400, 150)
+/* [comments]
+const addPos = area.nodeViews.get(add.id)!.position
+
+comment.addFrame('Frame comment — drag nodes in/out', [a.id, b.id])
+comment.addInline(/* [history] 'Inline comment — try Ctrl+Z after edit/delete' [/history] *//* [!history] 'Inline comment' [/!history] */, [addPos.x + 30, addPos.y - 30], add.id)
+[/comments] */
 [/!arrange] */
 
 /* [arrange]
@@ -252,6 +275,12 @@ arrange.addPreset(ArrangePresets.classic.setup());
 area.use(arrange)
 
 await arrange.layout()
+/* [comments]
+const addPos = area.nodeViews.get(add.id)!.position
+
+comment.addFrame('Frame comment — drag nodes in/out', [a.id, b.id])
+comment.addInline(/* [history] 'Inline comment — try Ctrl+Z after edit/delete' [/history] *//* [!history] 'Inline comment' [/!history] */, [addPos.x - 60, addPos.y - 62], add.id)
+[/comments] */
 [/arrange] */
 
 /* [zoom-at] AreaExtensions.zoomAt(area, editor.getNodes()) [/zoom-at] */
@@ -263,6 +292,7 @@ const selector = AreaExtensions.selector();
 const accumulating = AreaExtensions.accumulateOnCtrl();
 
 AreaExtensions.selectableNodes(area, selector, { accumulating });
+/* [comments] CommentExtensions.selectable(comment, selector, accumulating) [/comments] */
 /* [reroute]
 RerouteExtensions.selectablePins(reroutePlugin, selector, accumulating);
 [/reroute] */

--- a/src/app/features.ts
+++ b/src/app/features.ts
@@ -194,6 +194,26 @@ export class Selectable implements Feature {
   templateKeys: DefaultTemplateKey[] = ['import-area-extensions', 'selectable']
 }
 
+export class History implements Feature {
+  name = 'History'
+  templateKeys: DefaultTemplateKey[] = ['history']
+  requiredDependencies: string[] = []
+
+  constructor(next: boolean) {
+    this.requiredDependencies.push(ver('rete-history-plugin', next))
+  }
+}
+
+export class Comments implements Feature {
+  name = 'Comments'
+  templateKeys: DefaultTemplateKey[] = ['comments', 'sizes']
+  requiredDependencies: string[] = []
+
+  constructor(next: boolean) {
+    this.requiredDependencies.push(ver('rete-comment-plugin', next))
+  }
+}
+
 export class Area3D implements Feature {
   name = '3D'
   mandatory = true

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -89,6 +89,8 @@ export async function createApp({ name, stack, version, features, depsAlias, for
     new Features.ContextMenu(next),
     new Features.Minimap(next),
     new Features.Reroute(next),
+    new Features.Comments(next),
+    new Features.History(next),
     new Features.Scopes(next)
   ]
   const mandatoryFeatures = featuresList.filter(feature => feature.mandatory)

--- a/src/app/template-builder.ts
+++ b/src/app/template-builder.ts
@@ -13,7 +13,8 @@ export type DefaultTemplateKey = 'zoom-at' | 'react-render' | `react${number}` |
   | `vue${2 | 3}` | 'angular-render' | `angular${AngularVersion}`
   | 'svelte-render' | `svelte${SvelteVersion}` | 'lit-render' | `lit${3}`
   | 'dataflow' | 'arrange' | 'sizes' | 'readonly' | 'order-nodes' | 'selectable'
-  | 'context-menu' | 'import-area-extensions' | 'minimap' | 'reroute' | `stack-${string}`
+  | 'context-menu' | 'import-area-extensions' | 'minimap' | 'reroute' | 'history' | 'comments'
+  | `stack-${string}`
 
 export class TemplateBuilder<Key extends string> {
   blockCommentRegex = /\/\* \[(!?[\w-]+)\][\r\n ]+(.*?)?[\r\n ]?\[\/\1\] \*\//gs

--- a/test/template.test.ts
+++ b/test/template.test.ts
@@ -25,6 +25,58 @@ import { A } from 'pkg';
 const b = new A();\n`)
   })
 
+  it('builds history and comments integration', async () => {
+    const builder = new TemplateBuilder([
+      'history',
+      'comments',
+      'import-area-extensions',
+      'selectable'
+    ])
+    const template = await builder.load('default')
+    const code = await builder.build(template, false)
+
+    expect(code).toContain('HistoryPresets.comments.setup({ comment })')
+    expect(code).toContain('CommentExtensions.selectable(comment, selector, accumulating)')
+    expect(code).toContain('HistoryActions<Schemes> | CommentHistoryActions')
+    expect(code).toContain("comment.addInline('Inline comment — try Ctrl+Z after edit/delete'")
+  })
+
+  it('uses classic history actions without comments', async () => {
+    const builder = new TemplateBuilder(['history'])
+    const template = await builder.load('default')
+    const code = await builder.build(template, false)
+
+    expect(code).toContain('HistoryActions<Schemes>')
+    expect(code).not.toContain('CommentHistoryActions')
+    expect(code).not.toContain('HistoryPresets.comments.setup')
+    expect(code).not.toContain('CommentPlugin')
+    expect(code).not.toContain('CommentExtensions')
+  })
+
+  it('builds comments without history', async () => {
+    const builder = new TemplateBuilder(['comments', 'sizes', 'import-area-extensions', 'selectable'])
+    const template = await builder.load('default')
+    const code = await builder.build(template, false)
+
+    expect(code).toContain('CommentPlugin')
+    expect(code).toContain('comment.addFrame')
+    expect(code).toContain("comment.addInline('Inline comment',")
+    expect(code).not.toContain('Ctrl+Z')
+    expect(code).toContain('CommentExtensions.selectable(comment, selector, accumulating)')
+    expect(code).not.toContain('HistoryPlugin')
+    expect(code).not.toContain('HistoryPresets')
+    expect(code).not.toContain('HistoryExtensions.keyboard')
+  })
+
+  it('keeps comment selectable without history preset integration', async () => {
+    const builder = new TemplateBuilder(['comments', 'selectable', 'import-area-extensions', 'sizes'])
+    const template = await builder.load('default')
+    const code = await builder.build(template, false)
+
+    expect(code).toContain('CommentExtensions.selectable(comment, selector, accumulating)')
+    expect(code).not.toContain('HistoryPresets.comments.setup')
+  })
+
   it('handles CRLF line endings with nested blocks', () => {
     const builder = new TemplateBuilder(['selectable', 'reroute', 'dataflow'])
     const code = builder.build(

--- a/test/template.test.ts
+++ b/test/template.test.ts
@@ -3,16 +3,16 @@ import { describe, expect, it } from '@jest/globals'
 import { TemplateBuilder } from '../src/app/template-builder'
 
 describe('Template builder', () => {
-  const template = new TemplateBuilder(['add', 'line'])
+  const basicBuilder = new TemplateBuilder(['add', 'line'])
 
   it('single line', async () => {
-    const code = await template.build(`import { /* [add] A, [/add] */ B, /* [skip] C [/skip] */} from 'pkg';`)
+    const code = await basicBuilder.build(`import { /* [add] A, [/add] */ B, /* [skip] C [/skip] */} from 'pkg';`)
 
     expect(code).toEqual(`import { A, B } from 'pkg';\n`)
   })
 
   it('multiline', async () => {
-    const code = await template.build(`
+    const code = await basicBuilder.build(`
       import { A } from 'pkg';
 
       /* [skip] const a = new A() [/skip] */
@@ -32,8 +32,8 @@ const b = new A();\n`)
       'import-area-extensions',
       'selectable'
     ])
-    const template = await builder.load('default')
-    const code = await builder.build(template, false)
+    const source = await builder.load('default')
+    const code = await builder.build(source, false)
 
     expect(code).toContain('HistoryPresets.comments.setup({ comment })')
     expect(code).toContain('CommentExtensions.selectable(comment, selector, accumulating)')
@@ -43,8 +43,8 @@ const b = new A();\n`)
 
   it('uses classic history actions without comments', async () => {
     const builder = new TemplateBuilder(['history'])
-    const template = await builder.load('default')
-    const code = await builder.build(template, false)
+    const source = await builder.load('default')
+    const code = await builder.build(source, false)
 
     expect(code).toContain('HistoryActions<Schemes>')
     expect(code).not.toContain('CommentHistoryActions')
@@ -55,8 +55,8 @@ const b = new A();\n`)
 
   it('builds comments without history', async () => {
     const builder = new TemplateBuilder(['comments', 'sizes', 'import-area-extensions', 'selectable'])
-    const template = await builder.load('default')
-    const code = await builder.build(template, false)
+    const source = await builder.load('default')
+    const code = await builder.build(source, false)
 
     expect(code).toContain('CommentPlugin')
     expect(code).toContain('comment.addFrame')
@@ -70,8 +70,8 @@ const b = new A();\n`)
 
   it('keeps comment selectable without history preset integration', async () => {
     const builder = new TemplateBuilder(['comments', 'selectable', 'import-area-extensions', 'sizes'])
-    const template = await builder.load('default')
-    const code = await builder.build(template, false)
+    const source = await builder.load('default')
+    const code = await builder.build(source, false)
 
     expect(code).toContain('CommentExtensions.selectable(comment, selector, accumulating)')
     expect(code).not.toContain('HistoryPresets.comments.setup')


### PR DESCRIPTION
### Description

Adds **History** and **Comments** as optional features when scaffolding a Rete Kit app.

When both are selected, generated apps include undo/redo for comments (edit, delete, drag, frame membership). Each feature also works on its own — history for nodes/connections, comments with a small demo (frame + inline).

### Related Issues

https://github.com/retejs/comment-plugin/pull/50
https://github.com/retejs/history-plugin/pull/42

### Checklist

<!-- Mark the items that apply to this pull request -->

- [ ] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [ ] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).

### Additional Notes

<!-- Any additional information or notes for the reviewers. -->
